### PR TITLE
Remove erroneous references to CHARACTER_HERHIS_HIM loc key

### DIFF
--- a/WtWSMS/common/religion/religions/00_christianity.txt
+++ b/WtWSMS/common/religion/religions/00_christianity.txt
@@ -1885,7 +1885,7 @@
 				FertilityGodName = arian_fertility_god_name
 				FertilityGodNamePossessive = arian_fertility_god_name_possessive
 				FertilityGodSheHe = CHARACTER_SHEHE_HE
-				FertilityGodHerHis = CHARACTER_HERHIS_HIM
+				FertilityGodHerHis = CHARACTER_HERHIS_HIS
 				FertilityGodHerHim = CHARACTER_HERHIM_HIM
 
 				#WealthGod
@@ -1906,7 +1906,7 @@
 				KnowledgeGodName = arian_knowledge_god_name
 				KnowledgeGodNamePossessive = arian_knowledge_god_name_possessive
 				KnowledgeGodSheHe = CHARACTER_SHEHE_HE
-				KnowledgeGodHerHis = CHARACTER_HERHIS_HIM
+				KnowledgeGodHerHis = CHARACTER_HERHIS_HIS
 				KnowledgeGodHerHim = CHARACTER_HERHIM_HIM
 
 				#WarGod

--- a/WtWSMS/common/religion/religions/00_germanic.txt
+++ b/WtWSMS/common/religion/religions/00_germanic.txt
@@ -404,14 +404,14 @@
 				HealthGodName = gothic_health_god_name
 				HealthGodNamePossessive = gothic_health_god_name_possessive
 				FertilityGodSheHe = CHARACTER_SHEHE_HE
-				FertilityGodHerHis = CHARACTER_HERHIS_HIM
+				FertilityGodHerHis = CHARACTER_HERHIS_HIS
 				FertilityGodHerHim = CHARACTER_HERHIM_HIS
 				
 				#FertilityGod
 				FertilityGodName = gothic_fertility_god_name
 				FertilityGodNamePossessive = gothic_fertility_god_name_possessive
 				FertilityGodSheHe = CHARACTER_SHEHE_HE
-				FertilityGodHerHis = CHARACTER_HERHIS_HIM
+				FertilityGodHerHis = CHARACTER_HERHIS_HIS
 				FertilityGodHerHim = CHARACTER_HERHIM_HIS
 
 				#WealthGod

--- a/WtWSMS/common/religion/religions/00_kushitism.txt
+++ b/WtWSMS/common/religion/religions/00_kushitism.txt
@@ -95,7 +95,7 @@
 		WealthGodName = egyptian_wealth_god_name
 		WealthGodNamePossessive = egyptian_wealth_god_name_possessive
 		WealthGodSheHe = CHARACTER_SHEHE_HE
-		WealthGodHerHis = CHARACTER_HERHIS_HIM
+		WealthGodHerHis = CHARACTER_HERHIS_HIS
 		WealthGodHerHim = CHARACTER_HERHIM_HIM
 	
 		#HouseholdGod

--- a/WtWSMS/common/religion/religions/00_waaqism.txt
+++ b/WtWSMS/common/religion/religions/00_waaqism.txt
@@ -286,7 +286,7 @@ waaqism_religion = {
 				WealthGodName = semitic_wealth_god_name
 				WealthGodNamePossessive = semitic_wealth_god_name_possessive
 				WealthGodSheHe = CHARACTER_SHEHE_HE
-				WealthGodHerHis = CHARACTER_HERHIS_HIM
+				WealthGodHerHis = CHARACTER_HERHIS_HIS
 				WealthGodHerHim = CHARACTER_HERHIM_HIM
 				
 				#HouseholdGod

--- a/WtWSMS/common/religion/religions/BP_arabian.txt
+++ b/WtWSMS/common/religion/religions/BP_arabian.txt
@@ -92,7 +92,7 @@
 		WealthGodName = semitic_wealth_god_name
 		WealthGodNamePossessive = semitic_wealth_god_name_possessive
 		WealthGodSheHe = CHARACTER_SHEHE_HE
-		WealthGodHerHis = CHARACTER_HERHIS_HIM
+		WealthGodHerHis = CHARACTER_HERHIS_HIS
 		WealthGodHerHim = CHARACTER_HERHIM_HIM
 	
 		#HouseholdGod

--- a/WtWSMS/common/religion/religions/BP_assyrian.txt
+++ b/WtWSMS/common/religion/religions/BP_assyrian.txt
@@ -93,7 +93,7 @@ assyrian_religion = {
 		WealthGodName = assyrian_wealth_god_name
 		WealthGodNamePossessive = assyrian_wealth_god_name_possessive
 		WealthGodSheHe = CHARACTER_SHEHE_HE
-		WealthGodHerHis = CHARACTER_HERHIS_HIM
+		WealthGodHerHis = CHARACTER_HERHIS_HIS
 		WealthGodHerHim = CHARACTER_HERHIM_HIM
 	
 		#HouseholdGod
@@ -285,21 +285,21 @@ assyrian_religion = {
 				CreatorNamePossessive = shamsi_pagan_high_god_name_possessive
 				CreatorSheHe = CHARACTER_SHEHE_HE
 				CreatorHerHis = CHARACTER_HERHIS_HER
-				CreatorHerHim = CHARACTER_HERHIS_HIM
+				CreatorHerHim = CHARACTER_HERHIM_HIM
 				
 				#HealthGod
 				HealthGodName = shamsi_pagan_high_god_name
 				HealthGodNamePossessive = shamsi_pagan_high_god_name_possessive
 				HealthGodSheHe = CHARACTER_SHEHE_HE
 				HealthGodHerHis = CHARACTER_HERHIS_HER
-				HealthGodHerHim = CHARACTER_HERHIS_HIM
+				HealthGodHerHim = CHARACTER_HERHIM_HIM
 				
 				#FertilityGod
 				FertilityGodName = shamsi_pagan_high_god_name
 				FertilityGodNamePossessive = shamsi_pagan_high_god_name_possessive
 				FertilityGodSheHe = CHARACTER_SHEHE_HE
 				FertilityGodHerHis = CHARACTER_HERHIS_HER
-				FertilityGodHerHim = CHARACTER_HERHIS_HIM
+				FertilityGodHerHim = CHARACTER_HERHIM_HIM
 
 				#WealthGod
 				WealthGodName = shamsi_pagan_high_god_name
@@ -313,7 +313,7 @@ assyrian_religion = {
 				HouseholdGodNamePossessive = shamsi_pagan_high_god_name_possessive
 				HouseholdGodSheHe = CHARACTER_SHEHE_HE
 				HouseholdGodHerHis = CHARACTER_HERHIS_HER
-				HouseholdGodHerHim = CHARACTER_HERHIS_HIM
+				HouseholdGodHerHim = CHARACTER_HERHIM_HIM
 
 				#FateGod
 				FateGodName = shamsi_pagan_high_god_name
@@ -341,7 +341,7 @@ assyrian_religion = {
 				TricksterGodNamePossessive = shamsi_pagan_high_god_name_possessive
 				TricksterGodSheHe = CHARACTER_SHEHE_HE
 				TricksterGodHerHis = CHARACTER_HERHIS_HER
-				TricksterGodHerHim = CHARACTER_HERHIS_HIM
+				TricksterGodHerHim = CHARACTER_HERHIM_HIM
 
 				#NightGod
 				NightGodName = shamsi_pagan_high_god_name

--- a/WtWSMS/common/religion/religions/BP_georgian.txt
+++ b/WtWSMS/common/religion/religions/BP_georgian.txt
@@ -62,7 +62,7 @@
 		HighGodNamePossessive = georgian_high_god_name_possessive
 		HighGodNameSheHe = CHARACTER_SHEHE_HE
 		HighGodHerselfHimself = CHARACTER_HIMSELF
-		HighGodHerHis = CHARACTER_HERHIS_HIM
+		HighGodHerHis = CHARACTER_HERHIS_HIS
 		HighGodNameAlternate = georgian_high_god_name_alternate
 		HighGodNameAlternatePossessive = georgian_high_god_name_alternate_possessive
 
@@ -112,7 +112,7 @@
 		KnowledgeGodName = georgian_knowledge_god_name
 		KnowledgeGodNamePossessive = georgian_knowledge_god_name_possessive
 		KnowledgeGodSheHe = CHARACTER_SHEHE_HE
-		KnowledgeGodHerHis = CHARACTER_HERHIS_HIM
+		KnowledgeGodHerHis = CHARACTER_HERHIS_HIS
 		KnowledgeGodHerHim = CHARACTER_HERHIM_HIS
 
 		#WarGod

--- a/WtWSMS/common/religion/religions/BP_proto_carpathian.txt
+++ b/WtWSMS/common/religion/religions/BP_proto_carpathian.txt
@@ -60,7 +60,7 @@
 		HighGodNamePossessive = dacian_pagan_high_god_name_possessive
 		HighGodNameSheHe = CHARACTER_SHEHE_HE
 		HighGodHerselfHimself = CHARACTER_HIMSELF
-		HighGodHerHis = CHARACTER_HERHIS_HIM
+		HighGodHerHis = CHARACTER_HERHIS_HIS
 		HighGodNameAlternate = dacian_pagan_high_god_name_alternate
 		HighGodNameAlternatePossessive = dacian_pagan_high_god_name_alternate_possessive
 
@@ -69,7 +69,7 @@
 		CreatorNamePossessive = dacian_pagan_creator_god_name_possessive
 		CreatorSheHe = CHARACTER_SHEHE_HE
 		CreatorHerHis = CHARACTER_HIMSELF
-		CreatorHerHim = CHARACTER_HERHIS_HIM
+		CreatorHerHim = CHARACTER_HERHIM_HIM
 
 		#HealthGod
 		HealthGodName = dacian_pagan_health_god_name
@@ -257,7 +257,7 @@
 				HighGodNamePossessive = illyrian_pagan_high_god_name_possessive
 				HighGodNameSheHe = CHARACTER_SHEHE_HE
 				HighGodHerselfHimself = CHARACTER_HIMSELF
-				HighGodHerHis = CHARACTER_HERHIS_HIM
+				HighGodHerHis = CHARACTER_HERHIS_HIS
 				HighGodNameAlternate = illyran_pagan_high_god_name_alternate
 				HighGodNameAlternatePossessive = illyran_pagan_high_god_name_alternate_possessive
 
@@ -266,7 +266,7 @@
 				CreatorNamePossessive = illyran_pagan_creator_god_name_possessive
 				CreatorSheHe = CHARACTER_SHEHE_HE
 				CreatorHerHis = CHARACTER_HERHIS_HIS
-				CreatorHerHim = CHARACTER_HERHIS_HIM
+				CreatorHerHim = CHARACTER_HERHIM_HIM
 
 				#HealthGod
 				HealthGodName = illyrian_pagan_health_god_name
@@ -287,7 +287,7 @@
 				WealthGodNamePossessive = illyrian_pagan_wealth_god_name_possessive
 				WealthGodSheHe = CHARACTER_SHEHE_HE
 				WealthGodHerHis = CHARACTER_HERHIS_HIS
-				WealthGodHerHim = CHARACTER_HERHIS_HIM
+				WealthGodHerHim = CHARACTER_HERHIM_HIM
 
 				#HouseholdGod
 				HouseholdGodName = illyrian_pagan_household_god_name
@@ -301,21 +301,21 @@
 				FateGodNamePossessive = illyrian_pagan_fate_god_name_possessive
 				FateGodSheHe = CHARACTER_SHEHE_HE
 				FateGodHerHis = CHARACTER_HERHIS_HIS
-				FateGodHerHim = CHARACTER_HERHIS_HIM
+				FateGodHerHim = CHARACTER_HERHIM_HIM
 
 				#KnowledgeGod
 				KnowledgeGodName = illyrian_pagan_knowledge_god_name
 				KnowledgeGodNamePossessive = dacian_pagan_knowledge_god_name_possessive
 				KnowledgeGodSheHe = CHARACTER_SHEHE_HE
 				KnowledgeGodHerHis = CHARACTER_HERHIS_HIS
-				KnowledgeGodHerHim = CHARACTER_HERHIS_HIM
+				KnowledgeGodHerHim = CHARACTER_HERHIM_HIM
 
 				#WarGod
 				WarGodName = illyrian_pagan_war_god_name
 				WarGodNamePossessive = illyrian_pagan_war_god_name_possessive
 				WarGodSheHe = CHARACTER_SHEHE_HE
 				WarGodHerHis = CHARACTER_HERHIS_HIS
-				WarGodHerHim = CHARACTER_HERHIS_HIM
+				WarGodHerHim = CHARACTER_HERHIM_HIM
 
 				#TricksterGod
 				TricksterGodName = illyrian_pagan_trickster_god_name


### PR DESCRIPTION
CHARACTER_HERHIS_HIM loc is not defined.
Depending on usage (whether it's XHerHis or XHerHim), replaced the key with CHARACTER_HERHIS_HIS or CHARACTER_HERHIM_HIM.